### PR TITLE
Fix: Enable scrolling on the landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#1f2937" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -245,7 +245,7 @@ function App() {
 
   return (
     <div 
-      className={`text-gray-100 ${isMobile ? 'flex flex-col' : ''} ${currentView === 'gallery' ? 'overflow-auto' : 'overflow-hidden'}`} 
+      className={`text-gray-100 ${isMobile ? 'flex flex-col' : ''}`}
       style={{ 
         height: isMobile ? viewportHeight : 'auto', 
         minHeight: isMobile ? 'auto' : '100vh',

--- a/src/index.css
+++ b/src/index.css
@@ -17,13 +17,11 @@ button, input, select, textarea, label, a, li, ul, ol,
 /* Disable zoom and overscroll behavior on mobile */
 html, body {
   touch-action: pan-x pan-y;
-  overscroll-behavior: none;
   -webkit-user-select: none;
   user-select: none;
   -webkit-touch-callout: none;
   -webkit-tap-highlight-color: transparent;
   background-color: #09090b;
-  height: 100%;
 }
 
 /* Enhanced responsive typography */


### PR DESCRIPTION
The landing page was not scrollable due to a combination of restrictive CSS and HTML properties.

This commit addresses the issue by:
- Removing `maximum-scale=1.0` and `user-scalable=no` from the viewport meta tag in `index.html` to allow for better mobile interaction.
- Removing `height: 100%` and `overscroll-behavior: none` from the `html, body` styles in `src/index.css` to prevent the viewport from being locked to a fixed height.
- Removing the `overflow-hidden` class from the main App component in `src/App.tsx` which was preventing any content from overflowing the viewport.