### PR TITLE
Feat: Use environment variable for Gemini API key

### DIFF
--- a/src/components/FruitDetection.tsx
+++ b/src/components/FruitDetection.tsx
@@ -36,6 +36,12 @@ export const FruitDetection: React.FC<FruitDetectionProps> = ({
 
   // Get stored API key from localStorage on mount
   useEffect(() => {
+    const envApiKey = import.meta.env.VITE_GEMINI_API_KEY;
+    if (envApiKey) {
+      setApiKey(envApiKey);
+      initializeDetector(envApiKey);
+      return;
+    }
     const storedApiKey = localStorage.getItem('gemini-api-key');
     if (storedApiKey) {
       setApiKey(storedApiKey);
@@ -159,14 +165,16 @@ export const FruitDetection: React.FC<FruitDetectionProps> = ({
           {isActive ? <Eye size={20} /> : <EyeOff size={20} />}
         </button>
 
-        {/* Settings Toggle */}
-        <button
-          onClick={() => setShowSettings(!showSettings)}
-          className="p-3 rounded-full bg-zinc-900/80 backdrop-blur-xl border border-zinc-600 text-zinc-400 hover:text-white hover:scale-105 transition-all"
-          title="Detection Settings"
-        >
-          <Settings size={20} />
-        </button>
+        {/* Settings Toggle (only show if API key is not from env) */}
+        {!import.meta.env.VITE_GEMINI_API_KEY && (
+          <button
+            onClick={() => setShowSettings(!showSettings)}
+            className="p-3 rounded-full bg-zinc-900/80 backdrop-blur-xl border border-zinc-600 text-zinc-400 hover:text-white hover:scale-105 transition-all"
+            title="Detection Settings"
+          >
+            <Settings size={20} />
+          </button>
+        )}
 
         {/* Processing Indicator */}
         {isProcessing && (


### PR DESCRIPTION
This commit modifies the `FruitDetection` component to prioritize the `VITE_GEMINI_API_KEY` environment variable for the Gemini API key.

- If the `VITE_GEMINI_API_KEY` environment variable is set, the application will use it to initialize the fruit detector, and the settings UI for manual key entry will be hidden.
- If the environment variable is not set, the application falls back to the previous behavior, allowing the user to enter the API key manually via the settings panel.

This change aligns the application's behavior with the instructions in the `README.md` file while maintaining a user-friendly fallback for local development without a `.env` file.